### PR TITLE
Fixed HierarchyRequestError in Chrome

### DIFF
--- a/tz_detect/templates/tz_detect/detector.html
+++ b/tz_detect/templates/tz_detect/detector.html
@@ -7,7 +7,6 @@
     var tz_script = document.createElement('script');
     tz_script.src = '{{ STATIC_URL }}tz_detect/js/tzdetect{% if not DEBUG %}.min{% endif %}.js';
     tz_script.setAttribute('async', 'true');
-    document.documentElement.firstChild.appendChild(tz_script);
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(tz_script, s);
   })();
 


### PR DESCRIPTION
I could not get the detector javascript to run on Chrome without JS throwing a HierarchyRequestError. It seemed that the JS was trying to insert the dynamically created <script> tag inside the opening <html> tag. 

I just copied what GA does instead, searching for the first <script tag> (guaranteed to be at least one ... ours) and inserting after that.

Apologies it's in 3 commits. It's quite late here.
