### PR TITLE
Allow for correct timezone to be available upon the first page view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.egg-info
 dist
 build
+*.sqlite3

--- a/tz_detect/defaults.py
+++ b/tz_detect/defaults.py
@@ -5,3 +5,13 @@ from django.conf import settings
 # app's most popular countries first.
 # Defaults to top Internet using countries.
 TZ_DETECT_COUNTRIES = getattr(settings, 'TZ_DETECT_COUNTRIES', ('CN', 'US', 'IN', 'JP', 'BR', 'RU', 'DE', 'FR', 'GB'))
+
+# Should the page reload upon determination of the 
+# user's timezone. This allows your app to have the 
+# user's timezone available for the first page view.
+TZ_RELOAD = getattr(settings, 'TZ_RELOAD', False)
+
+# The default URL the user should be redirected to 
+# once their timezone has been stored. This only 
+# applies if TZ_RELOAD=True
+TZ_DEFAULT_RELOAD_URL = getattr(settings, 'TZ_DEFAULT_RELOAD_URL', '/')

--- a/tz_detect/settings.py
+++ b/tz_detect/settings.py
@@ -13,7 +13,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': '.db.sqllite3',
+        'NAME': '.db.sqlite3',
     }
 }
 
@@ -112,7 +112,11 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     'tz_detect',
+    'django_nose',
 )
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+NOSE_ARGS = '-s'
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/tz_detect/views.py
+++ b/tz_detect/views.py
@@ -1,23 +1,84 @@
-from django.http import HttpResponse
+import logging
+
+from django.http import HttpResponse, HttpResponseRedirect
 from django.views.generic import View
+from django.utils.http import is_safe_url
 
 from tz_detect.utilities import offset_to_timezone
+from tz_detect.defaults import TZ_DEFAULT_RELOAD_URL, TZ_RELOAD
+
+logger = logging.getLogger('tz_detect')
 
 
 class SetOffsetView(View):
-    http_method_names = ['post']
+    """ Handle the setting of the user's timezone offset in their session
 
-    def post(self, request, *args, **kwargs):
-        offset = request.POST.get('offset', None)
+    This view handles two cases:
+
+        1) Request via Ajax
+        2) Browser accessing the endpoint directly
+    
+    In the case of the former, we return errors as appropriate. For the 
+    latter, we always make sure we redirect the user onwards in a 
+    pleasent way (as we don't want to break the entire site due to a 
+    timezone error).
+
+    """
+    http_method_names = ['post', 'get']
+
+    def get_offset(self, request):
+        """Get the offset from the request"""
+        offset = request.REQUEST.get('offset', None)
         if not offset:
-            return HttpResponse("No 'offset' parameter provided", status=400)
+            raise ValueError("No 'offset' parameter provided")
 
         try:
             offset = int(offset)
         except ValueError:
-            return HttpResponse("Invalid 'offset' value provided", status=400)
+            raise ValueError("Invalid 'offset' value provided")
+
+        return offset
+
+    def get_redirect(self, request):
+        """Get a HttpResponseRedirect to use when TZ_RELOAD=True"""
+        next = request.REQUEST.get('next', None)
+        if next and not is_safe_url(next):
+            next = None
+
+        next = next or TZ_DEFAULT_RELOAD_URL
+        return HttpResponseRedirect(next)
+
+    def set_timezone(self, request):
+        """Get the offset for the given request
+        and set the timezone on the request's session"""
+        try:
+            offset = self.get_offset(request)
+        except ValueError, e:
+            logger.exception(e)
+            if request.is_ajax():
+                return HttpResponse(str(e), status=400)
+            else:
+                return self.get_redirect(request)
 
         tz = offset_to_timezone(int(offset))
         request.session['detected_tz'] = tz
 
-        return HttpResponse("OK")
+        if request.is_ajax():
+            return HttpResponse("OK")
+        else:
+            return self.get_redirect(request)
+
+    def post(self, request, *args, **kwargs):
+        return self.set_timezone(request)
+
+    def get(self, request, *args, **kwargs):
+        # Get requests not allowed for ajax requests or if TZ_RELOAD is disabled
+        if request.is_ajax() or not TZ_RELOAD:
+            return self.http_method_not_allowed(request, *args, **kwargs)
+
+        return self.set_timezone(request)
+
+    def http_method_not_allowed(self, request, *args, **kwargs):
+        # Just add a little logging here
+        logger.error('Invalid HTTP method when setting timezone.')
+        return super(SetOffsetView, self).http_method_not_allowed(request, *args, **kwargs)


### PR DESCRIPTION
I am working on this via the use of auto-reloading. The ``TZ_RELOAD`` option is being added which will cause the page to be reloaded when the timezone is first detected.

Task list:

- [x] Add ``TZ_RELOAD`` and ``TZ_DEFAULT_RELOAD_URL`` settings
- [x] Support non-ajax GET requests in SetOffsetView
- [ ] Create middleware to intercept initial request (is this a good idea?)
- [ ] Update client-side JavaScript