### PR TITLE
Support django 1.6+ default session serializer, JSONSerializer

### DIFF
--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from tz_detect.utilities import offset_to_timezone
 
 
 class TimezoneMiddleware(object):
@@ -8,6 +9,6 @@ class TimezoneMiddleware(object):
             # `request.timezone_active` is used in the template
             # tag to detect if the timezone has been activated
             request.timezone_active = True
-            timezone.activate(tz)
+            timezone.activate(offset_to_timezone(tz))
         else:
             timezone.deactivate()

--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from pytz.tzinfo import BaseTzInfo
 from tz_detect.utilities import offset_to_timezone
 
 
@@ -9,6 +10,10 @@ class TimezoneMiddleware(object):
             # `request.timezone_active` is used in the template
             # tag to detect if the timezone has been activated
             request.timezone_active = True
-            timezone.activate(offset_to_timezone(tz))
+            # for existing sessions storing BaseTzInfo objects
+            if type(tz) == BaseTzInfo:
+                timezone.activate(tz)
+            else:
+                timezone.activate(offset_to_timezone(tz))
         else:
             timezone.deactivate()

--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -11,7 +11,7 @@ class TimezoneMiddleware(object):
             # tag to detect if the timezone has been activated
             request.timezone_active = True
             # for existing sessions storing BaseTzInfo objects
-            if type(tz) == BaseTzInfo:
+            if isinstance(tz, BaseTzInfo):
                 timezone.activate(tz)
             else:
                 timezone.activate(offset_to_timezone(tz))

--- a/tz_detect/tests.py
+++ b/tz_detect/tests.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-from pytz.tzinfo import BaseTzInfo
-
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -23,7 +21,7 @@ class ViewTestCase(TestCase):
         response = SetOffsetView.as_view()(request)
         self.assertEqual(response.status_code, 200)
         self.assertIn('detected_tz', request.session)
-        self.assertIsInstance(request.session['detected_tz'], BaseTzInfo)
+        self.assertIsInstance(request.session['detected_tz'], int)
 
     def test_xhr_bad_method(self):
         from .views import SetOffsetView

--- a/tz_detect/views.py
+++ b/tz_detect/views.py
@@ -1,8 +1,6 @@
 from django.http import HttpResponse
 from django.views.generic import View
 
-from tz_detect.utilities import offset_to_timezone
-
 
 class SetOffsetView(View):
     http_method_names = ['post']
@@ -17,7 +15,6 @@ class SetOffsetView(View):
         except ValueError:
             return HttpResponse("Invalid 'offset' value provided", status=400)
 
-        tz = offset_to_timezone(int(offset))
-        request.session['detected_tz'] = tz
+        request.session['detected_tz'] = int(offset)
 
         return HttpResponse("OK")


### PR DESCRIPTION
Moved call to offset_to_timezone from view to middleware, so we only store the offset in the session. This allows the use of JSONSerializer instead of PickleSerializer for sessions, which was introduced as the default in Django 1.6