### PR TITLE
Don't use {% load url from future %}

### DIFF
--- a/tz_detect/templates/tz_detect/detector.html
+++ b/tz_detect/templates/tz_detect/detector.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% load staticfiles %}
 {% if show %}
 <script type="text/javascript">


### PR DESCRIPTION
Silence RemovedInDjango19Warning