### PR TITLE
Add Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.10,<1.11"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 before_install:
   - pip install -q $DJANGO
@@ -30,11 +31,15 @@ matrix:
     - python: "2.6"
       env: DJANGO="Django>=1.9,<1.10"
     - python: "2.6"
+      env: DJANGO="Django>=1.10,<1.11"
+    - python: "2.6"
       env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
     - python: "3.3"
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.3"
       env: DJANGO="Django>=1.9,<1.10"
+    - python: "3.3"
+      env: DJANGO="Django>=1.10,<1.11"
     - python: "3.3"
       env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
     - python: "3.4"

--- a/README.rst
+++ b/README.rst
@@ -80,14 +80,19 @@ Installation
        {% load tz_detect %}
        {% tz_detect %}
 
-6. Add ``TimezoneMiddleware`` to ``MIDDLEWARE_CLASSES``:
+6. Add ``TimezoneMiddleware`` to ``MIDDLEWARE`` or ``MIDDLEWARE_CLASSES``:
 
    .. code-block:: python
 
-       MIDDLEWARE_CLASSES = (
+       MIDDLEWARE = (  # Django >= 1.10
            ...
            'tz_detect.middleware.TimezoneMiddleware',
-        )
+       )
+
+       MIDDLEWARE_CLASSES = (  # Django < 1.10
+           ...
+           'tz_detect.middleware.TimezoneMiddleware',
+       )
 
 7. (Optional) Configure the countries in which your app will be most commonly used:
 

--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -10,10 +10,15 @@ try:
 except ImportError:
     import six
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    MiddlewareMixin = object
+
 from .utils import offset_to_timezone
 
 
-class TimezoneMiddleware(object):
+class TimezoneMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         tz = request.session.get('detected_tz')


### PR DESCRIPTION
Django 1.10 added a [new style of middleware](https://docs.djangoproject.com/en/1.10/releases/1.10/#new-style-middleware) that's incompatible with older versions.

[`django.utils.deprecation.MiddlewareMixin`](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#django.utils.deprecation.MiddlewareMixin) was also added to easily convert old-style middleware.