### PR TITLE
Travis config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django>=1.11,<2.0"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 before_install:
   - pip install -q $DJANGO
@@ -24,3 +25,7 @@ matrix:
   exclude:
     - python: "3.4"
       env: DJANGO="Django>=1.4,<1.5"
+    - python: "2.7"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"


### PR DESCRIPTION
* Add Django 1.11
* Exclude Python 2.7/Django master (because Django 2.0 will not support Python 2.7)
* Allow tests against Django master to fail