### PR TITLE
Add Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    py{27,34,35,36,py,py3}-dj1.{8,11}
+    py{34,35,36,py3}-dj2.0
+
+[testenv]
+commands = {envpython} setup.py test
+deps =
+    dj1.8: Django ~=1.8.0
+    dj1.11: Django ~=1.11.0
+    dj2.0: Django ~=2.0.0


### PR DESCRIPTION
This makes it convenient to test different Python / Django versions locally.

This currently lists all the Python and Django versions that are supported upstream.

(This doesn't update the CI configurations to invoke Tox, but that could be done in future.)