### PR TITLE
MIDDLEWARE_CLASSES renamed to MIDDLEWARE in Django 1.10

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
-django>=1.8
+django>=1.10
 pytz

--- a/example/settings.py
+++ b/example/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
 ] + PROJECT_APPS
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
[`MIDDLEWARE_CLASSES` was renamed to `MIDDLEWARE` back in Django 1.10.](https://docs.djangoproject.com/en/2.1/releases/1.10/#new-style-middleware)

I wanted to quickly verify that this was still working in Django 2.1.1. I did so using the example, but needed to update settings in order to get around this error:

```
Internal Server Error: /tz_detect/set/
Traceback (most recent call last):
  File "/Users/craiga/.ve/django-tz-detect-example/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/Users/craiga/.ve/django-tz-detect-example/lib/python3.7/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/craiga/.ve/django-tz-detect-example/lib/python3.7/site-packages/django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/craiga/.ve/django-tz-detect-example/lib/python3.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/craiga/.ve/django-tz-detect-example/lib/python3.7/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/craiga/django-tz-detect/tz_detect/views.py", line 20, in post
    request.session['detected_tz'] = int(offset)
AttributeError: 'WSGIRequest' object has no attribute 'session'
```