### PR TITLE
Django 3.0 deprecation: {% load staticfiles %} is deprecated in favor of {% load static %}

### DIFF
--- a/tz_detect/templates/tz_detect/detector.html
+++ b/tz_detect/templates/tz_detect/detector.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load url from compat %}
 {% if show %}
 <script type="text/javascript">


### PR DESCRIPTION
This avoids a `RemovedInDjango30Warning` as of Django 2.1.