### PR TITLE
Set attributes on script tag.

### DIFF
--- a/tz_detect/templates/tz_detect/detector.html
+++ b/tz_detect/templates/tz_detect/detector.html
@@ -1,6 +1,6 @@
 {% load static %}
 {% if show %}
-<script type="text/javascript">
+<script type="text/javascript"{% for key, value in script_attrs.items %} {{ key }}="{{ value }}"{% endfor %}>
   var csrf_token = "{{ csrf_token }}";
   var tz_set_endpoint = '{% url "tz_detect__set" %}';
   var csrf_header_name = '{{ csrf_header_name }}';

--- a/tz_detect/templatetags/tz_detect.py
+++ b/tz_detect/templatetags/tz_detect.py
@@ -8,11 +8,12 @@ register = template.Library()
 
 
 @register.inclusion_tag('tz_detect/detector.html', takes_context=True)
-def tz_detect(context):
+def tz_detect(context, **script_attrs):
     return {
         'show': not hasattr(context.get('request'), 'timezone_active'),
         'debug': getattr(settings, 'DEBUG', False),
         'csrf_header_name': convert_header_name(
             getattr(settings, 'CSRF_HEADER_NAME', 'HTTP_X_CSRFTOKEN')
         ),
+        'script_attrs': script_attrs,
     }


### PR DESCRIPTION
I've been playing about with [Content Security Policy headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), which tells the browser where the site expects different classes of content to come from.

For inline scripts, this means either adding a `nonce` attribute to each `script` element, or allowing `'unsafe-inline'`. Unsafe inline scripts would leave me vulnerable to some XSS exploits so I'd rather not use that, but django-tz-detect currently offers no way for me to add a nonce without overriding its template.

This PR adds the ability to add arbitrary attributes to this  `script` element injected by this tag.

For example, using this with [django-csp's recommended mechanism for adding a nonce](https://django-csp.readthedocs.io/en/latest/nonce.html) would look like this:

```
{% load tz_detect %}
{% tz_detect nonce=request.csp_nonce %}
```