### PR TITLE
Switch from `url` to `path` to fix a Django 4.0 deprecation warning.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Installation
    .. code-block:: python
 
        urlpatterns += [
-           url(r'^tz_detect/', include('tz_detect.urls')),
+           path('tz_detect/', include('tz_detect.urls')),
        ]
 
 5. Add the detection template tag to your site, ideally in your base layout just before the ``</body>`` tag:

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.conf.urls import include, path
 
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    url(r'^tz_detect/', include('tz_detect.urls')),
-    url(r'^$', TemplateView.as_view(template_name='index.html')),
+    path('tz_detect/', include('tz_detect.urls')),
+    path('', TemplateView.as_view(template_name='index.html')),
 ]

--- a/tz_detect/urls.py
+++ b/tz_detect/urls.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import url
+from django.conf.urls import path
 
 from .views import SetOffsetView
 
 urlpatterns = [
-    url(r'^set/$', SetOffsetView.as_view(), name="tz_detect__set"),
+    path("set/", SetOffsetView.as_view(), name="tz_detect__set"),
 ]


### PR DESCRIPTION
This change should address the following deprecation warning:

```
  /Users/matt/projects/homeschool/venv/lib/python3.9/site-packages/tz_detect/urls.py:8:
  RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
    url(r'^set/$', SetOffsetView.as_view(), name="tz_detect__set"),
```