### PR TITLE
Fix typo in urls.py path import

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import path
+from django.urls import path
 from django.urls import include
 from django.views.generic import TemplateView
 

--- a/tz_detect/urls.py
+++ b/tz_detect/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import path
+from django.urls import path
 
 from .views import SetOffsetView
 


### PR DESCRIPTION
When running the example using Django 4.0, I was getting the following error:

> ImportError: cannot import name 'path' from 'django.conf.urls'

urls.py [should be](https://docs.djangoproject.com/en/4.0/topics/http/urls/) importing path ```from django.urls``` not ```from django.conf.urls```

This is a small fix but it's working for me now.