### PR TITLE
Disable Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    # The requirements files used by tox are designed to test different versions
+    # of Django on purpose. Dependabot is noise for this package's use case.
+    # Setting the limit of open pull requests to zero is the documented way
+    # to disable Dependabot.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Dependabot is being silly and trying to upgrade older versions
in the test requirements files to the latest.
That's not what we want.

Ideally, we would instruct Dependabot to ignore those files,
but that capability is not available.
See https://github.com/dependabot/dependabot-core/issues/4364