### PR TITLE
Make the session key configurable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,9 @@ Installation
                'tz_detect.middleware.TimezoneMiddleware',
            )
 
-7. (Optional) Configure the countries in which your app will be most commonly used:
+7. (Optional) Configure optional settings
+
+   Set the countries in which your app will be most commonly used:
 
    .. code-block:: python
 
@@ -103,6 +105,13 @@ Installation
        # app's most popular countries first.
        # Defaults to the top Internet using countries.
        TZ_DETECT_COUNTRIES = ('CN', 'US', 'IN', 'JP', 'BR', 'RU', 'DE', 'FR', 'GB')
+
+   Set the session key that will be used to store the detected timezone
+
+   .. code-block:: python
+
+       # Session key to use, defaults to "detected_tz"
+       TZ_SESSOIN_KEY = "my-session-key"
 
 Please see ``example`` application. This application is used to manually
 test the functionalities of this package. This also serves as a good

--- a/tz_detect/defaults.py
+++ b/tz_detect/defaults.py
@@ -6,3 +6,7 @@ from django.conf import settings
 # Defaults to top Internet using countries.
 
 TZ_DETECT_COUNTRIES = getattr(settings, "TZ_DETECT_COUNTRIES", ("CN", "US", "IN", "JP", "BR", "RU", "DE", "FR", "GB"))
+
+
+# Session yey to use to store the detected timezone
+TZ_SESSION_KEY = getattr(settings, "TZ_SESSION_KEY", "detected_tz")

--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -2,6 +2,9 @@ import pytz
 from django.utils import timezone
 from pytz.tzinfo import BaseTzInfo
 
+from .defaults import TZ_SESSION_KEY
+
+
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:  # Django < 1.10
@@ -12,7 +15,7 @@ from .utils import offset_to_timezone
 
 class TimezoneMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        tz = request.session.get("detected_tz")
+        tz = request.session.get(TZ_SESSION_KEY)
         if tz:
             # ``request.timezone_active`` is used in the template tag
             # to detect if the timezone has been activated

--- a/tz_detect/tests.py
+++ b/tz_detect/tests.py
@@ -11,6 +11,8 @@ from tz_detect.templatetags.tz_detect import tz_detect
 from tz_detect.utils import convert_header_name, offset_to_timezone
 from tz_detect.views import SetOffsetView
 
+from .defaults import TZ_SESSION_KEY
+
 
 class ViewTestCase(TestCase):
     def setUp(self):
@@ -26,8 +28,8 @@ class ViewTestCase(TestCase):
 
         response = SetOffsetView.as_view()(request)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("detected_tz", request.session)
-        self.assertIsInstance(request.session["detected_tz"], int)
+        self.assertIn(TZ_SESSION_KEY, request.session)
+        self.assertIsInstance(request.session[TZ_SESSION_KEY], int)
 
     def test_xhr_valid_timezone(self):
         timezone_name = "Europe/Amsterdam"
@@ -36,8 +38,8 @@ class ViewTestCase(TestCase):
 
         response = SetOffsetView.as_view()(request)
         self.assertEqual(response.status_code, 200)
-        self.assertIn("detected_tz", request.session)
-        self.assertEqual(request.session["detected_tz"], timezone_name)
+        self.assertIn(TZ_SESSION_KEY, request.session)
+        self.assertEqual(request.session[TZ_SESSION_KEY], timezone_name)
 
     def test_xhr_bad_method(self):
         request = self.factory.get("/abc")
@@ -64,7 +66,7 @@ class ViewTestCase(TestCase):
         timezone_name = "Europe/Amsterdam"
         request = self.factory.post("/abc", {"timezone": timezone_name})
         self.add_session(request)
-        request.session["detected_tz"] = timezone_name
+        request.session[TZ_SESSION_KEY] = timezone_name
 
         get_response = lambda x: HttpResponse("")
         TimezoneMiddleware(get_response).process_request(request)

--- a/tz_detect/views.py
+++ b/tz_detect/views.py
@@ -2,13 +2,16 @@ from django.http import HttpResponse
 from django.views.generic import View
 
 
+from .defaults import TZ_SESSION_KEY
+
+
 class SetOffsetView(View):
     http_method_names = ["post"]
 
     def post(self, request, *args, **kwargs):
         timezone = request.POST.get("timezone", None)
         if timezone:
-            request.session["detected_tz"] = timezone
+            request.session[TZ_SESSION_KEY] = timezone
         else:
             offset = request.POST.get("offset", None)
             if not offset:
@@ -19,6 +22,6 @@ class SetOffsetView(View):
             except ValueError:
                 return HttpResponse("Invalid 'offset' value provided", status=400)
 
-            request.session["detected_tz"] = int(offset)
+            request.session[TZ_SESSION_KEY] = int(offset)
 
         return HttpResponse("OK")


### PR DESCRIPTION
Add a new setting TZ_SESSION_KEY which defaults to the current detected_tz. This will allow integration to other django projects that make assumptions about timezones and sessions.