### PR TITLE
Wrap timeZone in encodeURIComponent()

### DIFF
--- a/tz_detect/static/tz_detect/js/tzdetect.js
+++ b/tz_detect/static/tz_detect/js/tzdetect.js
@@ -66,7 +66,9 @@
         xmlHttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         xmlHttp.setRequestHeader(window.csrf_header_name, window.csrf_token);
         xmlHttp.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-        xmlHttp.send("offset=" + (new Date()).getTimezoneOffset() + '&timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone);
+        xmlHttp.send("offset=" + (new Date()).getTimezoneOffset()
+            + '&timezone=' + encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)
+        );
     }
 
 }());


### PR DESCRIPTION
This way timezones like Etc/GMT+3 will get sent correctly.

Before this change the backend interpreted "Etc/GMT+3" as "Etc/GMT 3", which is not a valid timezone.

This fixes #70 for new sessions.