### PR TITLE
Ignore invalid and unknown timezones in session

### DIFF
--- a/tz_detect/middleware.py
+++ b/tz_detect/middleware.py
@@ -17,15 +17,25 @@ class TimezoneMiddleware(MiddlewareMixin):
     def process_request(self, request):
         tz = request.session.get(TZ_SESSION_KEY)
         if tz:
-            # ``request.timezone_active`` is used in the template tag
-            # to detect if the timezone has been activated
-            request.timezone_active = True
-            # for existing sessions storing BaseTzInfo objects
-            if isinstance(tz, BaseTzInfo):
-                timezone.activate(tz)
-            elif isinstance(tz, str):
-                timezone.activate(pytz.timezone(tz))
-            else:
-                timezone.activate(offset_to_timezone(tz))
+            if self._try_to_set_timezone(tz):
+                # ``request.timezone_active`` is used in the template tag
+                # to detect if the timezone has been activated
+                request.timezone_active = True
+
         else:
             timezone.deactivate()
+
+    def _try_to_set_timezone(self, tz):
+        # for existing sessions storing BaseTzInfo objects
+        if isinstance(tz, BaseTzInfo):
+            timezone.activate(tz)
+        elif isinstance(tz, str):
+            try:
+                timezone.activate(pytz.timezone(tz))
+            except pytz.exceptions.UnknownTimeZoneError:
+                return False
+        else:
+            timezone.activate(offset_to_timezone(tz))
+
+        return True
+

--- a/tz_detect/tests.py
+++ b/tz_detect/tests.py
@@ -73,6 +73,18 @@ class ViewTestCase(TestCase):
         tz_name = get_current_timezone_name()
         self.assertEqual(tz_name, timezone_name)
 
+    def test_middleware_invalid_timezone_string(self):
+        timezone_name = "Etc/GMT 3"
+        request = self.factory.post("/abc", {"timezone": timezone_name})
+        self.add_session(request)
+        request.session[TZ_SESSION_KEY] = timezone_name
+
+        get_response = lambda x: HttpResponse("")
+        tz_name_before_middleware = get_current_timezone_name()
+        TimezoneMiddleware(get_response).process_request(request)
+        tz_name = get_current_timezone_name()
+        self.assertEqual(tz_name, tz_name_before_middleware)
+
 
 class OffsetToTimezoneTestCase(TestCase):
 


### PR DESCRIPTION
Don't crash when the time zone saved inside the session is invalid.

This helps with https://github.com/adamcharnock/django-tz-detect/issues/70, even for existing sessions.