### PR TITLE
Use the offset if the timezone is invalid

### DIFF
--- a/tz_detect/tests.py
+++ b/tz_detect/tests.py
@@ -41,6 +41,16 @@ class ViewTestCase(TestCase):
         self.assertIn(TZ_SESSION_KEY, request.session)
         self.assertEqual(request.session[TZ_SESSION_KEY], timezone_name)
 
+    def test_xhr_invalid_timezone_fallback(self):
+        timezone_name = "Etc/GMT 3"
+        request = self.factory.post("/abc", {"timezone": timezone_name, "offset": "-180"})
+        self.add_session(request)
+        response = SetOffsetView.as_view()(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(TZ_SESSION_KEY, request.session)
+        self.assertEqual(request.session[TZ_SESSION_KEY], -180)
+
     def test_xhr_bad_method(self):
         request = self.factory.get("/abc")
         self.add_session(request)

--- a/tz_detect/utils.py
+++ b/tz_detect/utils.py
@@ -46,3 +46,15 @@ def convert_header_name(django_header):
     'HTTP_CUSTOM_CSRF' -> 'custom-csrf'
     """
     return django_header.lower().replace("_", "-").split("http-")[-1]
+
+
+def is_valid_timezone(timezone):
+    """Check if a given string can be used as a timezone."""
+    if not timezone:
+        return False
+
+    try:
+        pytz.timezone(timezone)
+        return True
+    except pytz.exceptions.Error:
+        return False

--- a/tz_detect/views.py
+++ b/tz_detect/views.py
@@ -1,8 +1,8 @@
 from django.http import HttpResponse
 from django.views.generic import View
 
-
 from .defaults import TZ_SESSION_KEY
+from .utils import is_valid_timezone
 
 
 class SetOffsetView(View):
@@ -10,7 +10,7 @@ class SetOffsetView(View):
 
     def post(self, request, *args, **kwargs):
         timezone = request.POST.get("timezone", None)
-        if timezone:
+        if is_valid_timezone(timezone):
             request.session[TZ_SESSION_KEY] = timezone
         else:
             offset = request.POST.get("offset", None)


### PR DESCRIPTION
tz_detect assumes the server's time zone database contains the browser's time zone name. This might not always be the case.

This was inspired by work on the #70, I'm not sure how often such mismatch might occur.